### PR TITLE
chore(slider): Update default slider thumb label to always display

### DIFF
--- a/mintlify-docs/Components/Slider.mdx
+++ b/mintlify-docs/Components/Slider.mdx
@@ -24,7 +24,7 @@ iconType: "solid"
         **step (integer | float):** Step increment of the slider
 </Accordion>
 <Accordion title="thumb_label">
-        **thumb_label (boolean):** Displays the thumb label
+        **thumb_label (string):** Displays the thumb label
 </Accordion>
 <Accordion title="thumb_size">
         **thumb_size (integer):** Size of the thumb
@@ -62,7 +62,7 @@ sample_slider = zt.Slider(
     min = 0,  # Minimum value of the slider
     max = 100,  # Maximum value of the slider
     step = 1,  # Step increment of the slider
-    thumb_label = False,  # Displays the thumb label
+    thumb_label = 'always',  # Displays the thumb label
     thumb_size = 0,  # Size of the thumb
     tick_labels = 'always',  # When to display tick_labels
     ticks = [],  # Value of tick labels

--- a/zt_backend/models/components/slider.py
+++ b/zt_backend/models/components/slider.py
@@ -11,7 +11,7 @@ class Slider(ZTComponent):
     min: Union[int,float] = Field(0,  description="Minimum value of the slider")
     max: Union[int,float] = Field(100, description="Maximum value of the slider")
     step: Union[int,float] = Field(1,  description="Step increment of the slider")
-    thumb_label: bool = Field('always', description="Displays the thumb label")
+    thumb_label: str = Field('always', description="Displays the thumb label")
     thumb_size: int = Field(0, description="Size of the thumb")
     tick_labels: str = Field('always', description="When to display tick_labels")
     ticks: list = Field([], description="Value of tick labels")

--- a/zt_backend/models/components/slider.py
+++ b/zt_backend/models/components/slider.py
@@ -11,7 +11,7 @@ class Slider(ZTComponent):
     min: Union[int,float] = Field(0,  description="Minimum value of the slider")
     max: Union[int,float] = Field(100, description="Maximum value of the slider")
     step: Union[int,float] = Field(1,  description="Step increment of the slider")
-    thumb_label: bool = Field(False, description="Displays the thumb label")
+    thumb_label: bool = Field('always', description="Displays the thumb label")
     thumb_size: int = Field(0, description="Size of the thumb")
     tick_labels: str = Field('always', description="When to display tick_labels")
     ticks: list = Field([], description="Value of tick labels")


### PR DESCRIPTION
This PR introduces an enhancement to the slider component by ensuring that the thumb label is always visible:

Updated the slider thumb label property to ensure the thumb label is always visible.